### PR TITLE
fix slack message user image

### DIFF
--- a/hornet/slack.go
+++ b/hornet/slack.go
@@ -84,6 +84,7 @@ func (c *SlackClient) sendSlackMessage(channel, message, username string) error 
 	payload.Set("channel", channel)
 	payload.Set("text", message)
 	payload.Set("username", username)
+    payload.Set("as_user", "true") //does honet ever want to not do this?
 
 	res, err := http.PostForm(fmt.Sprintf("%s/%s", slackAddr, postMessageURI), payload)
 	if err != nil {


### PR DESCRIPTION
the as_user=true option posts as the user authenticated via token, as opposed to as Bot.

I just hard coded this, but maybe it should be an option somewhere. I'm sending as a pull request rather than merging so that you can review that before it goes in.
