### PR TITLE
add config option in watcher to ignore directories named something

### DIFF
--- a/examples/hornet_config.json
+++ b/examples/hornet_config.json
@@ -37,6 +37,10 @@
             "/otherdata1",
             "/otherdata2"
         ],
+        "ignore-dirs":
+        [
+            "lost+found"
+        ],
         "file-wait-time": "5s"
     },
 
@@ -52,7 +56,7 @@
             {
                 "name": "rsa-mat",
                 "match-regexp": "runid(?P<run_id>[0-9]*)_(?P<fname_other>[A-Za-z0-9_]*).mat",
-                "do-hash": true 
+                "do-hash": true
             },
             {
                 "name": "rsa-setup",


### PR DESCRIPTION
When changing hornet configs (e.g. streaming vs triggered delay times) we frequently may forget to purge the directory structure, resulting in a useless hornet.

This PR:
- causes hornet to recurse the watcher directory(ies) and pickup all existing subdirectories to watch
- adds an option to ignore a directory name (e.g. "lost+found")